### PR TITLE
Friends Star Icon Adjustment + Receive 'My Requests' Fix

### DIFF
--- a/gui/qt/friend_widget.py
+++ b/gui/qt/friend_widget.py
@@ -32,6 +32,8 @@ class FriendWidget(MyTreeWidget):
         self.setSortingEnabled(False)
         self.header().setResizeMode(1,2)
         self.header().setResizeMode(3,2)
+        self.setIconSize(QSize(115,20))
+        self.setIndentation(5)
 
     def update(self, items):
         self.clear()

--- a/gui/qt/themes/cleanlook/style.css
+++ b/gui/qt/themes/cleanlook/style.css
@@ -467,7 +467,7 @@ QHeaderView::section { /* Table Header Sections */
 }
 
 #contacts_container QHeaderView::section:first {
-    padding-left:40px;
+    padding-left:50px;
     padding-right:40px;
 }
 
@@ -570,6 +570,7 @@ QScrollBar:right-arrow {
 
 QTreeWidget {
     border: 0;
+    background-color:rgba(255,255,255,128);
 }
 
 QTreeWidget::item {


### PR DESCRIPTION
Fix for "My Requests" -- was showing up as black / unstyled on my box:

![image](https://cloud.githubusercontent.com/assets/7192646/12135349/bd78c80a-b3f7-11e5-9791-5c755000732c.png)

Stars were appearing, but were microscopic -- set icon size and adjusted margins a little bit

![image](https://cloud.githubusercontent.com/assets/7192646/12135355/cd3eebfc-b3f7-11e5-98a5-fd875a91077d.png)
